### PR TITLE
People update

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,8 @@ permalink: /news/:year/:month/:day/:title.html
 roles:
     - {key: faculty, name: Faculty}
     - {key: postdoc, name: Researchers}
-    - {key: staff, name: Staff}
+# We currently have no staff
+#    - {key: staff, name: Staff}
     - {key: grad, name: Graduate Students}
     - {key: collab, name: Collaborators}
     - {key: alum, name: Alumni}

--- a/_data/yml/people.yml
+++ b/_data/yml/people.yml
@@ -14,22 +14,14 @@ soroosh:
     bio: |
         Soroosh Afyouni is a postdoctoral research fellow at the University of Oxford. He is currently developing methods for threshold-free cluster enhancement (TFCE) method and multiple testing methods for neuroimaging data-sets. He has joined Oxford after undertaking an early career fellowship at the Warwick Institute of Advanced Study. In 2016, Soroosh received his PhD in Engineering from the University of Warwick where he developed methods for serial-correlation and Stochastic Block Modelling in functional connectivity of the human brain. In 2012, he received his Master of Engineering in Electronic Engineering from University of Birmingham where he worked on simulating the Spin-Echo sequences in Magnetic Resonance Imaging. Soroosh’s primary research interest is in functional connectivity and population connectomics. 
 
-simon:
-    display_name: "Simon Schwab"
-    image: "../img/people/SimonSchwab.jpg"
-    webpage: "https://schw4b.github.io/"
-    github: schw4b
-    role: postdoc
-    bio: |
-        Simon Schwab is a Visiting Fellow in Neuroimaging Statistics with Prof. Thomas Nichols at Oxford University, funded for the duration of 12 months by the Swiss National Science Foundation (SNSF). He is currently working on a new method of effective connectivity and its validation using functional MRI data from the Human Connectome Project and the UK Biobank. Before joining the University of Oxford, he worked with Tom Nichols at Warwick University and before that as a Postdoctoral Fellow at the Psychiatric Neuroimaging Unit at the University Hospital of Psychiatry in Bern, Switzerland. He received his Ph.D. in neuroscience (2013) and his M.Sc. in psychology and computer science (2008) from the University of Bern.
-
 tom_m:
     display_name: "Tom Maullin"
     image: "../img/people/TomMaullin.png"
     github: TomMaullin
-    role: staff
+    role: grad
     bio: |
-        Tom Maullin is a research assistant in the Big Data Institute at the University of Oxford. His primary role is to assist Thomas Nichols in developing standard practices for data sharing and meta-analysis in neuroimaging. In 2017 Tom completed his BSc. in Data Science from the University of Warwick. During his studies he undertook two software development projects, the first of which involved displaying standardised neuroimaging results and the second of which involved identifying sources of bias and heterogeneity within an image based meta-analysis.
+        Tom Maullin is a DPhil student in the Big Data Institute at the University of Oxford. His research interests include distributed machine learning, developing data sharing techniques and random field theory. Previously, he has developed software packages for the displaying standardised neuroimaging results and the identifying of sources of bias and heterogeneity within an image based meta-analysis, as well as made additions to and maintained pre-existing software packages such as the SwE-toolbox. 
+
 petya:
     display_name: "Petya Kindalova"
     image: "../img/people/PetyaKindalova.jpg"
@@ -44,13 +36,6 @@ sam:
     bio: |
         Sam Davenport is a PhD student at the University of Oxford on the OxWaSP Program, supervised by Thomas Nichols and Chris Holmes. Sam is currently working on Selective Inference methods to correct for bias in fMRI that arising due to the Winner's Curse. He is also looking at methods for dealing with Missing Data. He did his undergraduate in Mathematics at Cambridge before going on to do the Part III mathematics masters course there specialising in Statistics. His masters dissertation was entitled "Statistical Analysis in Neuroimaging Structural Breaks" which involved identifying changes in the brain using bootstrapping techniques and looking at multiple hypothesis testing in tree structures.
 
-han: 
-    display_name: Han Bossier
-    image: "../img/people/hanbossier.jpg"
-    role: grad
-    bio: |
-        Han first graduated as a master of science in experimental psychology at Ghent University. He then obtained a master of science in Statistical Data Analysis at the same university. During this period, he did an internship on data-analytical stability of fMRI results. Furthermore, he worked on fitting Probabilistic Index Models on very large datasets. Currently, he is a PhD student at the department of Data Analysis at Ghent University. As his interests grew towards methodological research in neuroscience, he now focusses on meta-analytical models and procedures in fMRI data analysis. He tries to incorporate his findings and recommendations in a broader framework of reproducibility and reliability of neuroscience.
-
 alex:
     display_name: "Alex Bowring"
     image: "../img/people/AlexBowring.jpg"
@@ -58,6 +43,15 @@ alex:
     role: grad
     bio: |
         Alex Bowring is a DPhil in Population Health student based in the Big Data Institute at the University of Oxford. His research is centred on functional MRI, with a particular focus on statistical methodology for neuroimaging analyses and developing open science practices. He is currently applying newly developed statistical methods to obtain precise confidence statements about where activation occurs in the brain for population neuroimaging studies, where thousands of subjects have been scanned. As well as this, he is also working on a software comparison project to understand the differences between the main neuroimaging software packages used for fMRI analyses.
+
+simon:
+    display_name: "Simon Schwab"
+    webpage: "https://schw4b.github.io/"
+    github: schw4b
+    role: collab
+    bio: |
+        Simon Schwab is a Research Associate in the Department of Biostatistics with Prof. Leonhard Held at the Epidemiology, Biostatistics and Prevention Institute in Switzerland. He is currently working on a new method of effective connectivity and its validation using functional MRI data from the Human Connectome Project and the UK Biobank. 
+
 camille:
     display_name: "Camille Maumet"
     webpage: "http://camillemaumet.com"
@@ -100,6 +94,12 @@ armin:
     bio: |
         Armin Schwartzman is an Associate Professor at University of California. His research areas include Statistical Signal and Image Analysis and Applications in biomedicine and the environment. His specialties include research, teaching, consulting and mathematical programming.
 
+han: 
+    display_name: Han Bossier
+    role: collab
+    bio: |
+        Han is a PhD student at the department of Data Analysis at Ghent University. He focusses on meta-analytical models and procedures in fMRI data analysis. He tries to incorporate his findings and recommendations in a broader framework of reproducibility and reliability of neuroscience.
+
 jessie:
     display_name: "Zhangdaihong (Jessie) Liu"
     image: "../img/people/JessieLiu.jpg"
@@ -109,11 +109,8 @@ jessie:
 
 ruth:
     display_name: "Ruth Harbord"
-    image: "../img/people/RuthHarbord.jpg"
-    role: grad
-    bio: |
-        Ruth Harbord is a PhD student with the MOAC Doctoral Training Centre, University of Warwick, supervised by Thomas Nichols. She is continuing the work of Dr. Lilia Costa on effective connectivity using fMRI data and graphical models. She completed the MOAC DTC MSc in Mathematical Biology and Biophysical Chemistry in 2013 and a BSc (Hons) in Physical Science from The Open University in 2011.
-
+    role: alum
+    bio: "Ph.D., 2018. Now at Trust Power, Oxford."
 
 anderson:
     display_name: "Anderson Winkler"

--- a/_site/people/index.html
+++ b/_site/people/index.html
@@ -222,136 +222,8 @@ Listed here are all collaborators, former members and current members of the <b>
   
     
     
-      <dt class="person">
-        
-        <a href="https://schw4b.github.io/">
-        
-          Simon Schwab
-        
-        </a>
-        
-      </dt>
-      <dd>
-        
-          
-            <br>
-            <p style = "float:left;margin-right:1em;padding-top:5px;"><img src="../img/people/SimonSchwab.jpg" alt="Simon Schwab" width="100"></p>
-          
-          <div style="column-count:1;text-align:justify"><p>Simon Schwab is a Visiting Fellow in Neuroimaging Statistics with Prof. Thomas Nichols at Oxford University, funded for the duration of 12 months by the Swiss National Science Foundation (SNSF). He is currently working on a new method of effective connectivity and its validation using functional MRI data from the Human Connectome Project and the UK Biobank. Before joining the University of Oxford, he worked with Tom Nichols at Warwick University and before that as a Postdoctoral Fellow at the Psychiatric Neuroimaging Unit at the University Hospital of Psychiatry in Bern, Switzerland. He received his Ph.D. in neuroscience (2013) and his M.Sc. in psychology and computer science (2008) from the University of Bern.</p>
-</div>
-        
-      </dd>
-      <hr>
-    
   
     
-    
-  
-    
-    
-  
-    
-    
-  
-    
-    
-  
-    
-    
-  
-    
-    
-  
-    
-    
-  
-    
-    
-  
-    
-    
-  
-    
-    
-  
-    
-    
-  
-    
-    
-  
-    
-    
-  
-    
-    
-  
-    
-    
-  
-    
-    
-  
-    
-    
-  
-    
-    
-  
-    
-    
-  
-    
-    
-  
-    
-    
-  
-    
-    
-  
-    
-    
-  
-    
-    
-  
-    
-    
-  
-  </dl>
-
-  <h3>Staff</h3>
-  <hr>
-  <dl class="people">
-  
-    
-    
-  
-    
-    
-  
-    
-    
-  
-    
-    
-      <dt class="person">
-        
-          Tom Maullin
-        
-      </dt>
-      <dd>
-        
-          
-            <br>
-            <p style = "float:left;margin-right:1em;padding-top:5px;"><img src="../img/people/TomMaullin.png" alt="Tom Maullin" width="100"></p>
-          
-          <div style="column-count:1;text-align:justify"><p>Tom Maullin is a research assistant in the Big Data Institute at the University of Oxford. His primary role is to assist Thomas Nichols in developing standard practices for data sharing and meta-analysis in neuroimaging. In 2017 Tom completed his BSc. in Data Science from the University of Warwick. During his studies he undertook two software development projects, the first of which involved displaying standardised neuroimaging results and the second of which involved identifying sources of bias and heterogeneity within an image based meta-analysis.</p>
-</div>
-        
-      </dd>
-      <hr>
     
   
     
@@ -440,8 +312,22 @@ Listed here are all collaborators, former members and current members of the <b>
   
     
     
-  
-    
+      <dt class="person">
+        
+          Tom Maullin
+        
+      </dt>
+      <dd>
+        
+          
+            <br>
+            <p style = "float:left;margin-right:1em;padding-top:5px;"><img src="../img/people/TomMaullin.png" alt="Tom Maullin" width="100"></p>
+          
+          <div style="column-count:1;text-align:justify"><p>Tom Maullin is a DPhil student in the Big Data Institute at the University of Oxford. His research interests include distributed machine learning, developing data sharing techniques and random field theory. Previously, he has developed software packages for the displaying standardised neuroimaging results and the identifying of sources of bias and heterogeneity within an image based meta-analysis, as well as made additions to and maintained pre-existing software packages such as the SwE-toolbox.</p>
+</div>
+        
+      </dd>
+      <hr>
     
   
     
@@ -488,26 +374,6 @@ Listed here are all collaborators, former members and current members of the <b>
     
       <dt class="person">
         
-          Han Bossier
-        
-      </dt>
-      <dd>
-        
-          
-            <br>
-            <p style = "float:left;margin-right:1em;padding-top:5px;"><img src="../img/people/hanbossier.jpg" alt="Han Bossier" width="100"></p>
-          
-          <div style="column-count:1;text-align:justify"><p>Han first graduated as a master of science in experimental psychology at Ghent University. He then obtained a master of science in Statistical Data Analysis at the same university. During this period, he did an internship on data-analytical stability of fMRI results. Furthermore, he worked on fitting Probabilistic Index Models on very large datasets. Currently, he is a PhD student at the department of Data Analysis at Ghent University. As his interests grew towards methodological research in neuroscience, he now focusses on meta-analytical models and procedures in fMRI data analysis. He tries to incorporate his findings and recommendations in a broader framework of reproducibility and reliability of neuroscience.</p>
-</div>
-        
-      </dd>
-      <hr>
-    
-  
-    
-    
-      <dt class="person">
-        
           Alex Bowring
         
       </dt>
@@ -522,6 +388,12 @@ Listed here are all collaborators, former members and current members of the <b>
         
       </dd>
       <hr>
+    
+  
+    
+    
+  
+    
     
   
     
@@ -563,23 +435,6 @@ Listed here are all collaborators, former members and current members of the <b>
     
   
     
-    
-      <dt class="person">
-        
-          Ruth Harbord
-        
-      </dt>
-      <dd>
-        
-          
-            <br>
-            <p style = "float:left;margin-right:1em;padding-top:5px;"><img src="../img/people/RuthHarbord.jpg" alt="Ruth Harbord" width="100"></p>
-          
-          <div style="column-count:1;text-align:justify"><p>Ruth Harbord is a PhD student with the MOAC Doctoral Training Centre, University of Warwick, supervised by Thomas Nichols. She is continuing the work of Dr. Lilia Costa on effective connectivity using fMRI data and graphical models. She completed the MOAC DTC MSc in Mathematical Biology and Biophysical Chemistry in 2013 and a BSc (Hons) in Physical Science from The Open University in 2011.</p>
-</div>
-        
-      </dd>
-      <hr>
     
   
     
@@ -644,8 +499,23 @@ Listed here are all collaborators, former members and current members of the <b>
   
     
     
-  
-    
+      <dt class="person">
+        
+        <a href="https://schw4b.github.io/">
+        
+          Simon Schwab
+        
+        </a>
+        
+      </dt>
+      <dd>
+        
+          
+          <div style="column-count:1;text-align:justify"><p>Simon Schwab is a Research Associate in the Department of Biostatistics with Prof. Leonhard Held at the Epidemiology, Biostatistics and Prevention Institute in Switzerland. He is currently working on a new method of effective connectivity and its validation using functional MRI data from the Human Connectome Project and the UK Biobank.</p>
+</div>
+        
+      </dd>
+      <hr>
     
   
     
@@ -772,6 +642,23 @@ Listed here are all collaborators, former members and current members of the <b>
   
     
     
+      <dt class="person">
+        
+          Han Bossier
+        
+      </dt>
+      <dd>
+        
+          
+          <div style="column-count:1;text-align:justify"><p>Han is a PhD student at the department of Data Analysis at Ghent University. He focusses on meta-analytical models and procedures in fMRI data analysis. He tries to incorporate his findings and recommendations in a broader framework of reproducibility and reliability of neuroscience.</p>
+</div>
+        
+      </dd>
+      <hr>
+    
+  
+    
+    
   
     
     
@@ -864,6 +751,20 @@ Listed here are all collaborators, former members and current members of the <b>
     
   
     
+    
+      <dt class="person">
+        
+          Ruth Harbord
+        
+      </dt>
+      <dd>
+        
+          
+          <div style="column-count:1;text-align:justify"><p>Ph.D., 2018. Now at Trust Power, Oxford.</p>
+</div>
+        
+      </dd>
+      <hr>
     
   
     


### PR DESCRIPTION
Hi @nicholst ,

This is a quick update to the list of people on the 'People' page of the website. Ruth has been moved to `Alumnis`, Simon and Han have been moved to `Collaborators` and I've been moved to `Graduate Students`. I have updated descriptions accordingly. Please let me know if this looks good to merge/if you have any suggestions!