### PR TITLE
Python Update Bug Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Because we are using a submodule, the repository has to be cloned with the recur
 git clone --recursive git@github.com:NISOx-BDI/NISOx-BDI.github.io.git
 ```
 
-To run the website locally, you will also need to install the dependencies: [Python](https://www.python.org/), [Pybtex](https://pybtex.org/) (`pip install pybtex`), [Jinja2](http://jinja.pocoo.org/docs/2.10/) (`pip install jinja2`) and [Jekyll](https://github.com/jekyll/jekyll) (`gem install jekyll`).
+To run the website locally, you will also need to install the dependencies: [Python](https://www.python.org/), [Pybtex](https://pybtex.org/) (`pip install pybtex`), [Jinja2](http://jinja.pocoo.org/docs/2.10/) (`pip install jinja2`) and [Jekyll](https://github.com/jekyll/jekyll) (`gem install jekyll`). Please note that the `Jinja2` install must be version `3.1.2` or higher, and the `Jekyll` install must be version `4.3.2` or higher.
 
 ## How to update the website?
 Except for the page including the publication list (cf. [below](#how-to-update-the-publication-list))  and the presentation pages (cf. [section 'How to update the presentations pages?'](#How to update the presentations pages?)), any new change pushed to the `master` branch of the current repository will automatically be reflected on the website. It is stronly advised to preview the changes locally before pushing to GitHub (cf. [section 'building'](#building)).

--- a/_layouts/publications.tmpl
+++ b/_layouts/publications.tmpl
@@ -47,7 +47,7 @@ title: "Publications"
 			{%- endif %}
 			<br />
 			<span class="links">
-			{%- for type, url in (entry|extra_urls).iteritems() %}
+			{%- for type, url in (entry|extra_urls).items() %}
 				[<a href="{{ url|escape }}">{{ type|escape }}</a>]
 			{%- endfor %}
 <!-- 				{%- if entry.fields['abstract'] %}

--- a/bibble/bibble.py
+++ b/bibble/bibble.py
@@ -57,6 +57,8 @@ def _author_Shorten(authorList):
     return shortenedAuthorList
 
 def _andlist(ss, sep=', ', seplast=', and ', septwo=' and '):
+    # Convert to list
+    ss = list(ss)
     #This function creates a list of authors from a set of authors.
     if len(ss) <= 1:
         return ''.join(ss)

--- a/bibble/bibble.py
+++ b/bibble/bibble.py
@@ -268,13 +268,13 @@ def main(bibfile, template, pageObj):
     
     #If we are creating a publications page just print out the template.
     if pageObj == 'Publications':
-        print(out.encode("utf-8"))
+        print(out)
     #If we are looking at Research pages work out where to save them and output
     #to there.
     else:
         fname = os.path.join(os.path.dirname(PATH), 'research', pageObj['name'], 'index.html')
         with open(fname, 'w') as f:
-            f.write(out.encode("utf8"))
+            f.write(out)
 
 if __name__ == '__main__':
     main(*sys.argv[1:])

--- a/bibble/bibble.py
+++ b/bibble/bibble.py
@@ -178,7 +178,7 @@ def _extra_urls(entry):
           ... }
     """
     urls = {}
-    for k, v in entry.fields.iteritems():
+    for k, v in entry.fields.items():
         if not k.endswith('_url'):
             continue
         k = k[:-4]


### PR DESCRIPTION
Hi @nicholst, 

Here are the bug fixes for the NISOx website found by me and Yang. Hopefully, these should fix the errors you were experiencing. This PR includes the following bug fixes and updates:

 - It appears the UTF-8 Encoding in `bibble.py` was not outputting in the expected format, and has therefore been removed.
 - Sometime after Python 3.5, it seems the `iteritems` function became deprecated and then was removed entirely. It has now been replaced with `items`.
 - The `map` function now returns an iterator, rather than something resembling a list. This means that when we ran `len` on maps, we ued to get the number of items, but now we just get an error. This has been fixed by converting maps to lists in `bibble.py`.
 - The `Readme.md` file has been updated to include version numbers for `Jekyll` and `Jinja2` that are known to work following this update.

Please let me know how this works for you.