### PR TITLE
Map fix for presentation generation

### DIFF
--- a/bibble/presGen.py
+++ b/bibble/presGen.py
@@ -65,6 +65,8 @@ def _author_Shorten(authorList, numAuthors):
     return shortenedAuthorList
 
 def _andlist(ss, sep=', ', seplast=', and ', septwo=' and '):
+    # Convert to list
+    ss = list(ss)
     #This function lists the authors.
     if len(ss) <= 1:
         return ''.join(ss)


### PR DESCRIPTION
Hi @nicholst ,

This is just a quick PR to resolve the error you have in your email. The problem is that the python `map` datatype no longer has a length attribute, so it needed to be converted to a list. This was an error we already found and resolved in the `_andlist` function in `bibble.py` but hadn't realised the function was copy-pasted in `presGen.py` too